### PR TITLE
Add_functions_to_User_Session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!, only: :index
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :authenticate_user!, only: :index
+  before_action :authenticate_user!
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])

--- a/app/views/chats/index.html.haml
+++ b/app/views/chats/index.html.haml
@@ -6,7 +6,7 @@
     .left-content
       .top-left-content.clearfix
         %p
-          YUHIJACKMAN
+          =current_user.nickname
           =link_to fa_icon("edit 2x")
           =link_to fa_icon("cog 2x")
       .bottom-left-content

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,8 +10,9 @@
         .field
           .field-label
             = f.label :nickname
+            %em (6 characters maximum)
           .field-input
-            = f.text_field :nickname, autofocus: true
+            = f.text_field :nickname, autofocus: true, maxlength:"6"
         .field
           .field-label
             = f.label :email


### PR DESCRIPTION
# WHAT
- ログインしていない状態での、indexページへの移動を防ぐよう設定する
- ニックネームの入力文字数の設定

# WHY
- ログインしているユーザーが、チャットページに入ることを防ぐため
- 短い名前で登録できないようにするため